### PR TITLE
feat: Automate willpower spending on dice rolls

### DIFF
--- a/module/scripts/roll-dice.js
+++ b/module/scripts/roll-dice.js
@@ -128,6 +128,13 @@ export async function DiceRoller(diceRoll) {
 	}
 
 	if (usewillpower) {
+		if (actor) {
+			let currentWillpower = actor.system.advantages.willpower.temporary;
+			if (currentWillpower > 0) {
+				let newWillpower = currentWillpower - 1;
+				await actor.update({"system.advantages.willpower.temporary": newWillpower});
+			}
+		}
 		rolledAnySuccesses = true;
 		bonusSuccesses += 1;
 	}


### PR DESCRIPTION
This change automatically deducts a point of temporary Willpower when a user opts to use it on a roll, streamlining gameplay.